### PR TITLE
Problem: The example doesnt compile on windows

### DIFF
--- a/examples/Robot1/OrientationMeasurementModel.hpp
+++ b/examples/Robot1/OrientationMeasurementModel.hpp
@@ -42,10 +42,10 @@ class OrientationMeasurementModel : public Kalman::LinearizedMeasurementModel<St
 {
 public:
     //! State type shortcut definition
-    typedef State<T> S;
+    typedef KalmanExamples::Robot1::State<T> S;
     
     //! Measurement type shortcut definition
-    typedef OrientationMeasurement<T> M;
+    typedef  KalmanExamples::Robot1::OrientationMeasurement<T> M;
     
     OrientationMeasurementModel()
     {

--- a/examples/Robot1/PositionMeasurementModel.hpp
+++ b/examples/Robot1/PositionMeasurementModel.hpp
@@ -51,10 +51,10 @@ class PositionMeasurementModel : public Kalman::LinearizedMeasurementModel<State
 {
 public:
     //! State type shortcut definition
-    typedef State<T> S;
+    typedef  KalmanExamples::Robot1::State<T> S;
     
     //! Measurement type shortcut definition
-    typedef PositionMeasurement<T> M;
+    typedef  KalmanExamples::Robot1::PositionMeasurement<T> M;
     
     /**
      * @brief Constructor

--- a/examples/Robot1/SystemModel.hpp
+++ b/examples/Robot1/SystemModel.hpp
@@ -81,10 +81,10 @@ class SystemModel : public Kalman::LinearizedSystemModel<State<T>, Control<T>, C
 {
 public:
     //! State type shortcut definition
-    typedef State<T> S;
+	typedef KalmanExamples::Robot1::State<T> S;
     
     //! Control type shortcut definition
-    typedef Control<T> C;
+    typedef KalmanExamples::Robot1::Control<T> C;
     
     /**
      * @brief Definition of (non-linear) state transition function

--- a/examples/Robot1/main.cpp
+++ b/examples/Robot1/main.cpp
@@ -9,9 +9,8 @@
 #include <random>
 #include <chrono>
 
-#ifdef _WIN32
-#define M_PI 3.14159265358979323846
-#endif
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 
 using namespace KalmanExamples;

--- a/examples/Robot1/main.cpp
+++ b/examples/Robot1/main.cpp
@@ -9,6 +9,11 @@
 #include <random>
 #include <chrono>
 
+#ifdef _WIN32
+#define M_PI 3.14159265358979323846
+#endif
+
+
 using namespace KalmanExamples;
 
 typedef float T;

--- a/examples/Robot1/main.cpp
+++ b/examples/Robot1/main.cpp
@@ -1,3 +1,10 @@
+
+// this MUST be first, otherwise there might be problems on windows
+// see: https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio/6563891#6563891
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+
 #include "SystemModel.hpp"
 #include "OrientationMeasurementModel.hpp"
 #include "PositionMeasurementModel.hpp"
@@ -8,9 +15,6 @@
 #include <iostream>
 #include <random>
 #include <chrono>
-
-#define _USE_MATH_DEFINES
-#include <cmath>
 
 
 using namespace KalmanExamples;


### PR DESCRIPTION
Solution: add namespaces, because the MSVC gets confused with `State` being defined as a class - and as a typedef in the base class

further: M_PI is missing...

Results look fine on MSVC 14/ VS 2015