### PR TITLE
add timestep to prediction methods in system models

### DIFF
--- a/examples/Robot1/SystemModel.hpp
+++ b/examples/Robot1/SystemModel.hpp
@@ -98,7 +98,7 @@ public:
      * @param [in] u The control vector input
      * @returns The (predicted) system state in the next time-step
      */
-    S f(const S& x, const C& u) const
+    S f(const S& x, const C& u, const double& dt = 0) const
     {
         //! Predicted state vector after transition
         S x_;

--- a/include/kalman/ExtendedKalmanFilter.hpp
+++ b/include/kalman/ExtendedKalmanFilter.hpp
@@ -120,6 +120,29 @@ namespace Kalman {
         }
         
         /**
+         * @brief Perform filter prediction step using control input \f$u\f$, timestep \f$dt\f$, and corresponding system model
+         *
+         * @param [in] s The System model
+         * @param [in] u The Control input vector
+         * @param [in] dt The timestep
+         * @return The updated state estimate
+         */
+        template<class Control, template<class> class CovarianceBase>
+        const State& predict( SystemModelType<Control, CovarianceBase>& s, const Control& u, const double& dt)
+        {
+            s.updateJacobians( x, u, dt);
+            
+            // predict state
+            x = s.f(x, u, dt);
+            
+            // predict covariance
+            P  = ( s.F * P * s.F.transpose() ) + ( s.W * s.getCovariance() * s.W.transpose() );
+            
+            // return state prediction
+            return this->getState();
+        }
+
+        /**
          * @brief Perform filter update step using measurement \f$z\f$ and corresponding measurement model
          *
          * @param [in] m The Measurement model

--- a/include/kalman/LinearizedSystemModel.hpp
+++ b/include/kalman/LinearizedSystemModel.hpp
@@ -61,7 +61,7 @@ namespace Kalman {
         /**
          * Callback function for state-dependent update of Jacobi-matrices F and W before each update step
          */
-        virtual void updateJacobians( const State& x, const Control& u )
+        virtual void updateJacobians( const State& x, const Control& u , const double& dt = 0)
         {
             // No update by default
             (void)x;

--- a/include/kalman/SquareRootExtendedKalmanFilter.hpp
+++ b/include/kalman/SquareRootExtendedKalmanFilter.hpp
@@ -120,6 +120,29 @@ namespace Kalman {
         }
         
         /**
+         * @brief Perform filter prediction step using control input \f$u\f$, timestep \f$dt\f$, and corresponding system model
+         *
+         * @param [in] s The System model
+         * @param [in] u The Control input vector
+         * @param [in] dt The timestep
+         * @return The updated state estimate
+         */
+        template<class Control, template<class> class CovarianceBase>
+        const State& predict( SystemModelType<Control, CovarianceBase>& s, const Control& u, const double& dt)
+        {
+            s.updateJacobians( x, u, dt);
+            
+            // predict state
+            x = s.f(x, u, dt);
+            
+            // predict covariance
+            computePredictedCovarianceSquareRoot<State>(s.F, S, s.W, s.getCovarianceSquareRoot(), S);
+            
+            // return state prediction
+            return this->getState();
+        }
+        
+        /**
          * @brief Perform filter update step using measurement \f$z\f$ and corresponding measurement model
          *
          * @param [in] m The Measurement model

--- a/include/kalman/SystemModel.hpp
+++ b/include/kalman/SystemModel.hpp
@@ -58,7 +58,7 @@ namespace Kalman {
          * Computes the predicted system state in the next timestep given
          * the current state x and the control input u
          */
-        virtual State f(const State& x, const Control& u) const = 0;
+        virtual State f(const State& x, const Control& u, const double& dt = 0) const = 0;
         
     protected:
         SystemModel() {}

--- a/test/models/Quadratic.hpp
+++ b/test/models/Quadratic.hpp
@@ -19,7 +19,7 @@ public:
     using typename Base::State;
     using typename Base::Control;
     
-    State f(const State& x, const Control& u) const
+    State f(const State& x, const Control& u, const double& dt = 1) const
     {
         // return x.^2 + u
         return x.cwiseProduct(x) + u;


### PR DESCRIPTION
It would be useful to account for timestep in the prediction methods.  I added logic to extend the system models to optionally use the timestep in the prediction methods.